### PR TITLE
dmg: Allow to statically link against OpenSSL

### DIFF
--- a/dmg/CMakeLists.txt
+++ b/dmg/CMakeLists.txt
@@ -2,12 +2,6 @@ INCLUDE(FindOpenSSL)
 INCLUDE(FindZLIB)
 INCLUDE(FindBZip2)
 
-FIND_LIBRARY(CRYPTO_LIBRARIES crypto
-      PATHS
-      /usr/lib
-      /usr/local/lib
-   )
-
 IF(NOT ZLIB_FOUND)
 	message(FATAL_ERROR "zlib is required for dmg!")
 ENDIF(NOT ZLIB_FOUND)
@@ -27,7 +21,7 @@ add_library(dmg adc.c base64.c checksum.c dmgfile.c dmglib.c filevault.c io.c pa
 IF(OPENSSL_FOUND)
 	add_definitions(-DHAVE_CRYPT)
 	include_directories(${OPENSSL_INCLUDE_DIR})
-	target_link_libraries(dmg ${CRYPTO_LIBRARIES})
+	target_link_libraries(dmg ${OPENSSL_CRYPTO_LIBRARY} $<$<BOOL:${OPENSSL_USE_STATIC_LIBS}>:${CMAKE_DL_LIBS}>)
 	IF(WIN32)
 		TARGET_LINK_LIBRARIES(dmg gdi32)
 	ENDIF(WIN32)


### PR DESCRIPTION
It turns out FindOpenSSL, which is included:
- respects the OPENSSL_USE_STATIC_LIBS to force the openssl libraries to
  be linked statically (and only those).
- provides variables for the individual libraries.

The latter means dmg/CMakeLists.txt doesn't actually need to search for
libcrypto on its own, but can just use whatever FindOpenSSL found, which
respects OPENSSL_USE_STATIC_LIBS.

Unfortunately, statically linking libcrypto requires linking against
libdl, so we also link CMAKE_DL_LIBS when OPENSSL_USE_STATIC_LIBS is set.