### PR TITLE
Memset a UDIF header to ensure archive reproducibility.

### DIFF
--- a/dmg/dmglib.c
+++ b/dmg/dmglib.c
@@ -107,8 +107,8 @@ int buildDmg(AbstractFile* abstractIn, AbstractFile* abstractOut, unsigned int B
 	
 	ChecksumToken dataForkToken;
 	
-	UDIFResourceFile koly;
-	
+	UDIFResourceFile koly = {0};
+
 	off_t plistOffset;
 	uint32_t plistSize;
 	uint32_t dataForkChecksum;
@@ -294,8 +294,8 @@ int convertToDMG(AbstractFile* abstractIn, AbstractFile* abstractOut) {
 	uint32_t dataForkChecksum;
 	uint64_t numSectors;
 	
-	UDIFResourceFile koly;
-	
+	UDIFResourceFile koly = {0};
+
 	char partitionName[512];
 	
 	off_t fileLength;


### PR DESCRIPTION
For Tor Browser, we have used the following patch for many years (but with another fork).

I am not sure it is needed also with Mozilla's fork (I see that fb0da705381165cca93a0c5825cdd8d44738ad0b is already about making `dmg` deterministic), but `memset`ting the whole struct anyway seems a good idea to me.

The original author of the patch is Mike Perry.