### PR TITLE
Parallelize dmg building

### DIFF
--- a/dmg/CMakeLists.txt
+++ b/dmg/CMakeLists.txt
@@ -27,7 +27,7 @@ IF(OPENSSL_FOUND)
 	ENDIF(WIN32)
 ENDIF(OPENSSL_FOUND)
 
-target_link_libraries(dmg common hfs z bz2)
+target_link_libraries(dmg common hfs z bz2 pthread)
 
 add_executable(dmg-bin dmg.c)
 target_link_libraries (dmg-bin dmg)

--- a/dmg/attribution.c
+++ b/dmg/attribution.c
@@ -81,12 +81,12 @@ void sentinelObserveBuffers(AbstractAttribution* attribution, int didKeepRaw, co
 
 		  CRCProxy(&attributionData->raw_UncompressedChkToken, uncompressedData, uncompressedLen);
 		  attributionData->raw_UncompressedLength = uncompressedLen;
-		  printf("Adding to raw_UncompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->raw_UncompressedChkToken.crc, attributionData->raw_UncompressedLength);
+		  // printf("Adding to raw_UncompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->raw_UncompressedChkToken.crc, attributionData->raw_UncompressedLength);
 
 		  // Of course, the compressed data *should* be the uncompressed data.
 		  CRCProxy(&attributionData->raw_CompressedChkToken, compressedData, compressedLen);
 		  attributionData->raw_CompressedLength = compressedLen;
-		  printf("Adding to raw_CompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->raw_CompressedChkToken.crc, attributionData->raw_CompressedLength);
+		  // printf("Adding to raw_CompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->raw_CompressedChkToken.crc, attributionData->raw_CompressedLength);
 
 		  attributionData->afterRaw_UncompressedLength = 0;
 		  attributionData->afterRaw_CompressedLength = 0;
@@ -98,31 +98,31 @@ void sentinelObserveBuffers(AbstractAttribution* attribution, int didKeepRaw, co
 		else {
 		  CRCProxy(&attributionData->raw_UncompressedChkToken, uncompressedData, uncompressedLen);
 		  attributionData->raw_UncompressedLength += uncompressedLen;
-		  printf("Appending to raw_UncompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->raw_UncompressedChkToken.crc, attributionData->raw_UncompressedLength);
+		  // printf("Appending to raw_UncompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->raw_UncompressedChkToken.crc, attributionData->raw_UncompressedLength);
 
 		  CRCProxy(&attributionData->raw_CompressedChkToken, compressedData, compressedLen);
 		  attributionData->raw_CompressedLength += compressedLen;
-		  printf("Appending to raw_CompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->raw_CompressedChkToken.crc, attributionData->raw_CompressedLength);
+		  // printf("Appending to raw_CompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->raw_CompressedChkToken.crc, attributionData->raw_CompressedLength);
 		}
 	} else {
 		if (attributionData->afterRaw_UncompressedLength < 0) {
 			CRCProxy(&attributionData->beforeRaw_UncompressedChkToken, uncompressedData, uncompressedLen);
 			attributionData->beforeRaw_UncompressedLength += uncompressedLen;
-			printf("Adding to beforeRaw_UncompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->beforeRaw_UncompressedChkToken.crc, attributionData->beforeRaw_UncompressedLength);
+			// printf("Adding to beforeRaw_UncompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->beforeRaw_UncompressedChkToken.crc, attributionData->beforeRaw_UncompressedLength);
 		} else {
 			CRCProxy(&attributionData->afterRaw_UncompressedChkToken, uncompressedData, uncompressedLen);
 			attributionData->afterRaw_UncompressedLength += uncompressedLen;
-			printf("Adding to afterRaw_UncompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->afterRaw_UncompressedChkToken.crc, attributionData->afterRaw_UncompressedLength);
+			// printf("Adding to afterRaw_UncompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->afterRaw_UncompressedChkToken.crc, attributionData->afterRaw_UncompressedLength);
 		}
 
 		if (attributionData->afterRaw_CompressedLength < 0) {
 			CRCProxy(&attributionData->beforeRaw_CompressedChkToken, compressedData, compressedLen);
 			attributionData->beforeRaw_CompressedLength += compressedLen;
-			printf("Adding to beforeRaw_CompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->beforeRaw_CompressedChkToken.crc, attributionData->beforeRaw_CompressedLength);
+			// printf("Adding to beforeRaw_CompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->beforeRaw_CompressedChkToken.crc, attributionData->beforeRaw_CompressedLength);
 		} else {
 			CRCProxy(&attributionData->afterRaw_CompressedChkToken, compressedData, compressedLen);
 			attributionData->afterRaw_CompressedLength += compressedLen;
-			printf("Adding to afterRaw_CompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->afterRaw_CompressedChkToken.crc, attributionData->afterRaw_CompressedLength);
+			// printf("Adding to afterRaw_CompressedChkToken, now CRC32: %x, length: %llx\n", attributionData->afterRaw_CompressedChkToken.crc, attributionData->afterRaw_CompressedLength);
 		}
 	}
 }

--- a/dmg/attribution.c
+++ b/dmg/attribution.c
@@ -71,7 +71,7 @@ void sentinelBeforeMainBlkx(AbstractAttribution* attribution, AbstractFile* abst
 void sentinelObserveBuffers(AbstractAttribution* attribution, int didKeepRaw, const void* uncompressedData, size_t uncompressedLen, const void* compressedData, size_t compressedLen) {
 	AttributionPreservingSentinelData* attributionData = (AttributionPreservingSentinelData*)attribution->data;
 
-	if (didKeepRaw == KeepCurrentRaw || didKeepRaw == KeepCurrentAndNextRaw) {
+	if (didKeepRaw) {
 		// If this is our first time in, we need to set up `raw_*` and `afterRaw*`
 		// from scratch.
 		if (attributionData->afterRaw_UncompressedLength < 0) {

--- a/dmg/checksum.c
+++ b/dmg/checksum.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <zlib.h>
 
 #include <dmg/dmg.h>
 
@@ -35,13 +36,6 @@ void CRCProxy(void* token, const unsigned char* data, size_t len) {
   CRC32Checksum(&(ckSumToken->crc), data, len);
 }
 
-void CRCZeroesProxy(void* token, size_t len) 
-{
-    ChecksumToken* ckSumToken;
-    ckSumToken = (ChecksumToken*) token;
-    CRC32ZeroesChecksum(&(ckSumToken->crc), len);
-}
-
 /*
  *
  * MediaKit block checksumming reverse-engineered from Leopard MediaKit framework
@@ -69,131 +63,11 @@ uint32_t MKBlockChecksum(uint32_t* ckSum, const unsigned char* data, size_t len)
   return myCkSum;
 }
 
-
-/*
- * CRC32 code ripped off (and adapted) from the zlib-1.1.3 distribution by Jean-loup Gailly and Mark Adler.
- *
- * Copyright (C) 1995-1998 Mark Adler
- * For conditions of distribution and use, see copyright notice in zlib.h
- *
- */
-
-/* ========================================================================
- * Table of CRC-32's of all single-byte values (made by make_crc_table)
- */
-static uint64_t crc_table[256] = {
-  0x00000000L, 0x77073096L, 0xee0e612cL, 0x990951baL, 0x076dc419L,
-  0x706af48fL, 0xe963a535L, 0x9e6495a3L, 0x0edb8832L, 0x79dcb8a4L,
-  0xe0d5e91eL, 0x97d2d988L, 0x09b64c2bL, 0x7eb17cbdL, 0xe7b82d07L,
-  0x90bf1d91L, 0x1db71064L, 0x6ab020f2L, 0xf3b97148L, 0x84be41deL,
-  0x1adad47dL, 0x6ddde4ebL, 0xf4d4b551L, 0x83d385c7L, 0x136c9856L,
-  0x646ba8c0L, 0xfd62f97aL, 0x8a65c9ecL, 0x14015c4fL, 0x63066cd9L,
-  0xfa0f3d63L, 0x8d080df5L, 0x3b6e20c8L, 0x4c69105eL, 0xd56041e4L,
-  0xa2677172L, 0x3c03e4d1L, 0x4b04d447L, 0xd20d85fdL, 0xa50ab56bL,
-  0x35b5a8faL, 0x42b2986cL, 0xdbbbc9d6L, 0xacbcf940L, 0x32d86ce3L,
-  0x45df5c75L, 0xdcd60dcfL, 0xabd13d59L, 0x26d930acL, 0x51de003aL,
-  0xc8d75180L, 0xbfd06116L, 0x21b4f4b5L, 0x56b3c423L, 0xcfba9599L,
-  0xb8bda50fL, 0x2802b89eL, 0x5f058808L, 0xc60cd9b2L, 0xb10be924L,
-  0x2f6f7c87L, 0x58684c11L, 0xc1611dabL, 0xb6662d3dL, 0x76dc4190L,
-  0x01db7106L, 0x98d220bcL, 0xefd5102aL, 0x71b18589L, 0x06b6b51fL,
-  0x9fbfe4a5L, 0xe8b8d433L, 0x7807c9a2L, 0x0f00f934L, 0x9609a88eL,
-  0xe10e9818L, 0x7f6a0dbbL, 0x086d3d2dL, 0x91646c97L, 0xe6635c01L,
-  0x6b6b51f4L, 0x1c6c6162L, 0x856530d8L, 0xf262004eL, 0x6c0695edL,
-  0x1b01a57bL, 0x8208f4c1L, 0xf50fc457L, 0x65b0d9c6L, 0x12b7e950L,
-  0x8bbeb8eaL, 0xfcb9887cL, 0x62dd1ddfL, 0x15da2d49L, 0x8cd37cf3L,
-  0xfbd44c65L, 0x4db26158L, 0x3ab551ceL, 0xa3bc0074L, 0xd4bb30e2L,
-  0x4adfa541L, 0x3dd895d7L, 0xa4d1c46dL, 0xd3d6f4fbL, 0x4369e96aL,
-  0x346ed9fcL, 0xad678846L, 0xda60b8d0L, 0x44042d73L, 0x33031de5L,
-  0xaa0a4c5fL, 0xdd0d7cc9L, 0x5005713cL, 0x270241aaL, 0xbe0b1010L,
-  0xc90c2086L, 0x5768b525L, 0x206f85b3L, 0xb966d409L, 0xce61e49fL,
-  0x5edef90eL, 0x29d9c998L, 0xb0d09822L, 0xc7d7a8b4L, 0x59b33d17L,
-  0x2eb40d81L, 0xb7bd5c3bL, 0xc0ba6cadL, 0xedb88320L, 0x9abfb3b6L,
-  0x03b6e20cL, 0x74b1d29aL, 0xead54739L, 0x9dd277afL, 0x04db2615L,
-  0x73dc1683L, 0xe3630b12L, 0x94643b84L, 0x0d6d6a3eL, 0x7a6a5aa8L,
-  0xe40ecf0bL, 0x9309ff9dL, 0x0a00ae27L, 0x7d079eb1L, 0xf00f9344L,
-  0x8708a3d2L, 0x1e01f268L, 0x6906c2feL, 0xf762575dL, 0x806567cbL,
-  0x196c3671L, 0x6e6b06e7L, 0xfed41b76L, 0x89d32be0L, 0x10da7a5aL,
-  0x67dd4accL, 0xf9b9df6fL, 0x8ebeeff9L, 0x17b7be43L, 0x60b08ed5L,
-  0xd6d6a3e8L, 0xa1d1937eL, 0x38d8c2c4L, 0x4fdff252L, 0xd1bb67f1L,
-  0xa6bc5767L, 0x3fb506ddL, 0x48b2364bL, 0xd80d2bdaL, 0xaf0a1b4cL,
-  0x36034af6L, 0x41047a60L, 0xdf60efc3L, 0xa867df55L, 0x316e8eefL,
-  0x4669be79L, 0xcb61b38cL, 0xbc66831aL, 0x256fd2a0L, 0x5268e236L,
-  0xcc0c7795L, 0xbb0b4703L, 0x220216b9L, 0x5505262fL, 0xc5ba3bbeL,
-  0xb2bd0b28L, 0x2bb45a92L, 0x5cb36a04L, 0xc2d7ffa7L, 0xb5d0cf31L,
-  0x2cd99e8bL, 0x5bdeae1dL, 0x9b64c2b0L, 0xec63f226L, 0x756aa39cL,
-  0x026d930aL, 0x9c0906a9L, 0xeb0e363fL, 0x72076785L, 0x05005713L,
-  0x95bf4a82L, 0xe2b87a14L, 0x7bb12baeL, 0x0cb61b38L, 0x92d28e9bL,
-  0xe5d5be0dL, 0x7cdcefb7L, 0x0bdbdf21L, 0x86d3d2d4L, 0xf1d4e242L,
-  0x68ddb3f8l, 0x1fda836eL, 0x81be16cdL, 0xf6b9265bL, 0x6fb077e1L,
-  0x18b74777L, 0x88085ae6L, 0xff0f6a70L, 0x66063bcaL, 0x11010b5cL,
-  0x8f659effL, 0xf862ae69L, 0x616bffd3L, 0x166ccf45L, 0xa00ae278L,
-  0xd70dd2eeL, 0x4e048354L, 0x3903b3c2L, 0xa7672661L, 0xd06016f7L,
-  0x4969474dL, 0x3e6e77dbL, 0xaed16a4aL, 0xd9d65adcL, 0x40df0b66L,
-  0x37d83bf0L, 0xa9bcae53L, 0xdebb9ec5L, 0x47b2cf7fL, 0x30b5ffe9L,
-  0xbdbdf21cL, 0xcabac28aL, 0x53b39330L, 0x24b4a3a6L, 0xbad03605L,
-  0xcdd70693L, 0x54de5729L, 0x23d967bfL, 0xb3667a2eL, 0xc4614ab8L,
-  0x5d681b02L, 0x2a6f2b94L, 0xb40bbe37L, 0xc30c8ea1L, 0x5a05df1bL,
-  0x2d02ef8dL
-};
-
-/* ========================================================================= */
-#define DO1(expr) crc = crc_table[((int)crc ^ (expr)) & 0xff] ^ (crc >> 8);
-#define DO2(expr)  DO1(expr); DO1(expr);
-#define DO4(expr)  DO2(expr); DO2(expr);
-#define DO8(expr)  DO4(expr); DO4(expr);
-
-/* ========================================================================= */
 uint32_t CRC32Checksum(uint32_t* ckSum, const unsigned char *buf, size_t len)
 {
-  uint32_t crc;
-  
-  crc = *ckSum;
-  
-  if (buf == NULL) return crc;
-  
-  crc = crc ^ 0xffffffffL;
-  while (len >= 8)
-  {
-    DO8(*buf++); // intentionally incrementing multiple times
-    len -= 8;
-  }
-  if (len)
-  {
-    do {
-DO1(*buf++);
-    } while (--len);
-  }
-  
-  crc = crc ^ 0xffffffffL;
-  
-  *ckSum = crc;
-  return crc;
+  return (*ckSum = crc32_z(*ckSum, buf, len));
 }
 
-uint32_t CRC32ZeroesChecksum(uint32_t* ckSum, size_t len)
-{
-    uint32_t crc;
-    
-    crc = *ckSum;
-    
-    crc = crc ^ 0xffffffffL;
-    while (len >= 8)
-    {
-        DO8(0);
-        len -= 8;
-    }
-    if (len)
-    {
-        do {
-            DO1(0);
-        } while (--len);
-    }
-    
-    crc = crc ^ 0xffffffffL;
-    
-    *ckSum = crc;
-    return crc;
-}
 /*
 SHA-1 in C
 By Steve Reid <steve@edmweb.com>

--- a/dmg/checksum.c
+++ b/dmg/checksum.c
@@ -65,7 +65,7 @@ uint32_t MKBlockChecksum(uint32_t* ckSum, const unsigned char* data, size_t len)
 
 uint32_t CRC32Checksum(uint32_t* ckSum, const unsigned char *buf, size_t len)
 {
-  return (*ckSum = crc32_z(*ckSum, buf, len));
+  return (*ckSum = crc32(*ckSum, buf, len));
 }
 
 /*

--- a/dmg/dmglib.c
+++ b/dmg/dmglib.c
@@ -159,7 +159,7 @@ int buildDmg(AbstractFile* abstractIn, AbstractFile* abstractOut, unsigned int B
 	}
 
 	blkx = insertBLKX(abstractOut, abstractIn, USER_OFFSET, (volumeHeader->totalBlocks * volumeHeader->blockSize)/SECTOR_SIZE,
-				pNum, CHECKSUM_UDIF_CRC32, &BlockSHA1CRC, &uncompressedToken, &CRCProxy, &dataForkToken, volume, 0, attribution);
+				pNum, CHECKSUM_UDIF_CRC32, &BlockSHA1CRC, &uncompressedToken, &CRCProxy, &dataForkToken, volume, attribution);
 
 	AttributionResource attributionResource;
 	memset(&attributionResource, 0, sizeof(AttributionResource));
@@ -371,7 +371,7 @@ int convertToDMG(AbstractFile* abstractIn, AbstractFile* abstractOut) {
 			
 			abstractIn->seek(abstractIn, partitions[i].pmPyPartStart * BlockSize);
 			blkx = insertBLKX(abstractOut, abstractIn, partitions[i].pmPyPartStart, partitions[i].pmPartBlkCnt, i, CHECKSUM_UDIF_CRC32,
-						&BlockCRC, &uncompressedToken, &CRCProxy, &dataForkToken, NULL, 0, NULL);
+						&BlockCRC, &uncompressedToken, &CRCProxy, &dataForkToken, NULL, NULL);
 			
 			blkx->checksum.data[0] = uncompressedToken.crc;	
 			resources = insertData(resources, "blkx", i, partitionName, 0, false, (const char*) blkx, sizeof(BLKXTable) + (blkx->blocksRunCount * sizeof(BLKXRun)), ATTRIBUTE_HDIUTIL);
@@ -412,7 +412,7 @@ int convertToDMG(AbstractFile* abstractIn, AbstractFile* abstractOut) {
 		
 		abstractIn->seek(abstractIn, 0);
 		blkx = insertBLKX(abstractOut, abstractIn, 0, fileLength/SECTOR_SIZE, ENTIRE_DEVICE_DESCRIPTOR, CHECKSUM_UDIF_CRC32,
-					&BlockCRC, &uncompressedToken, &CRCProxy, &dataForkToken, NULL, 0, NULL);
+					&BlockCRC, &uncompressedToken, &CRCProxy, &dataForkToken, NULL, NULL);
 		blkx->checksum.data[0] = uncompressedToken.crc;
 		resources = insertData(resources, "blkx", 0, "whole disk (unknown partition : 0)", 0, false, (const char*) blkx, sizeof(BLKXTable) + (blkx->blocksRunCount * sizeof(BLKXRun)), ATTRIBUTE_HDIUTIL);
 		free(blkx);

--- a/dmg/io.c
+++ b/dmg/io.c
@@ -133,8 +133,9 @@ void *threadWorker(void* arg) {
 			ASSERT(FALSE, "BZ2_bzCompress");
 		}
 		b.outsize = d->bufferSize - strm.avail_out;
-
-		if(d->keepRaw == KeepCurrentRaw || d->keepRaw == KeepCurrentAndNextRaw || ((b.outsize / SECTOR_SIZE) >= (b.run.sectorCount - 15))) {
+		
+		int keepRaw = (d->keepRaw == KeepCurrentRaw || d->keepRaw == KeepCurrentAndNextRaw);
+		if(keepRaw || ((b.outsize / SECTOR_SIZE) >= (b.run.sectorCount - 15))) {
 			// printf("Setting type = BLOCK_RAW\n");
 			b.run.type = BLOCK_RAW;
 			ASSERT(d->out->write(d->out, b.inbuf, b.run.sectorCount * SECTOR_SIZE) == (b.run.sectorCount * SECTOR_SIZE), "fwrite");
@@ -146,7 +147,7 @@ void *threadWorker(void* arg) {
 
 			if (d->attribution) {
 				// In a raw block, uncompressed and compressed data is identical.
-				d->attribution->observeBuffers(d->attribution, d->keepRaw,
+				d->attribution->observeBuffers(d->attribution, keepRaw,
 											b.inbuf, b.run.sectorCount * SECTOR_SIZE,
 											b.inbuf, b.run.sectorCount * SECTOR_SIZE);
 			}
@@ -158,7 +159,7 @@ void *threadWorker(void* arg) {
 
 			if (d->attribution) {
 				// In a bzip2 block, uncompressed and compressed data are not the same.
-				d->attribution->observeBuffers(d->attribution, d->keepRaw,
+				d->attribution->observeBuffers(d->attribution, keepRaw,
 											b.inbuf, b.insize,
 											b.outbuf, b.outsize);
 			}

--- a/dmg/io.c
+++ b/dmg/io.c
@@ -49,7 +49,6 @@ typedef struct {
 	uint32_t curRun;
 	uint64_t curSector;
 	size_t bufferSize;
-	int IGNORE_THRESHOLD;
 	uint64_t startOff;
 	enum ShouldKeepRaw keepRaw;
 } threadData;
@@ -197,7 +196,6 @@ BLKXTable* insertBLKX(AbstractFile* out_, AbstractFile* in_, uint32_t firstSecto
 		.compressedChk = compressedChk_,
 		.compressedChkToken = compressedChkToken_,
 		.attribution = attribution_,
-		.IGNORE_THRESHOLD = 100000,
 	};
 
 	td.blkx = (BLKXTable*) malloc(sizeof(BLKXTable) + (2 * sizeof(BLKXRun)));

--- a/dmg/io.c
+++ b/dmg/io.c
@@ -135,7 +135,7 @@ void *threadWorker(void* arg) {
 		b.outsize = d->bufferSize - strm.avail_out;
 
 		if(d->keepRaw == KeepCurrentRaw || d->keepRaw == KeepCurrentAndNextRaw || ((b.outsize / SECTOR_SIZE) >= (b.run.sectorCount - 15))) {
-			printf("Setting type = BLOCK_RAW\n");
+			// printf("Setting type = BLOCK_RAW\n");
 			b.run.type = BLOCK_RAW;
 			ASSERT(d->out->write(d->out, b.inbuf, b.run.sectorCount * SECTOR_SIZE) == (b.run.sectorCount * SECTOR_SIZE), "fwrite");
 			b.run.compLength += b.run.sectorCount * SECTOR_SIZE;

--- a/dmg/io.c
+++ b/dmg/io.c
@@ -180,7 +180,7 @@ void *threadWorker(void* arg) {
 			}
 		}
 
-		printf("run %d: sectors=%" PRId64 ", left=%d\n", d->curRun, d->blkx->runs[d->curRun].sectorCount, d->numSectors);
+		// printf("run %d: sectors=%" PRId64 ", left=%d\n", d->curRun, d->blkx->runs[d->curRun].sectorCount, d->numSectors);
 
 		ASSERT(BZ2_bzCompressInit(&strm, 9, 0, 0) == BZ_OK, "BZ2_bzCompressInit");
 
@@ -205,7 +205,7 @@ void *threadWorker(void* arg) {
 			else if (d->keepRaw == KeepCurrentRaw) {
 				d->keepRaw = KeepRemainingRaw;
 			}
-			printf("keepRaw = %d (%p, %ld)\n", d->keepRaw, b.inbuf, b.insize);
+			// printf("keepRaw = %d (%p, %ld)\n", d->keepRaw, b.inbuf, b.insize);
 		}
 
 		if(d->uncompressedChk)

--- a/dmg/io.c
+++ b/dmg/io.c
@@ -36,23 +36,26 @@ typedef struct {
 } block;
 
 typedef struct {
-	AbstractFile* out;
+	size_t bufferSize;
+	AbstractAttribution* attribution;
+
+	// Read
 	AbstractFile* in;
 	uint32_t numSectors;
+	uint32_t curRun;
+	uint64_t curSector;
+	uint64_t startOff;
+	unsigned char *nextInBuffer;	
+	enum ShouldKeepRaw keepRaw;
+
+	// Write
+	AbstractFile* out;
+	BLKXTable *blkx;
+	uint32_t roomForRuns;
 	ChecksumFunc uncompressedChk;
 	void* uncompressedChkToken;
 	ChecksumFunc compressedChk;
 	void* compressedChkToken;
-	AbstractAttribution* attribution;
-	unsigned char *nextInBuffer;	
-
-	BLKXTable *blkx;
-	uint32_t roomForRuns;
-	uint32_t curRun;
-	uint64_t curSector;
-	size_t bufferSize;
-	uint64_t startOff;
-	enum ShouldKeepRaw keepRaw;
 } threadData;
 
 block* blockAlloc(size_t bufferSize) {

--- a/dmg/io.c
+++ b/dmg/io.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <zlib.h>
 #include <bzlib.h>
+#include <pthread.h>
 
 #include <dmg/dmg.h>
 #include <dmg/adc.h>
@@ -322,7 +323,11 @@ BLKXTable* insertBLKX(AbstractFile* out_, AbstractFile* in_, uint32_t firstSecto
 		}
 	}
 
-	threadWorker(&td);
+	pthread_t thread;
+	ASSERT(pthread_create(&thread, NULL, threadWorker, &td) == 0, "pthread_create");
+	void *ret;
+	ASSERT(pthread_join(thread, &ret) == 0, "pthread_join");
+	ASSERT(ret == NULL, "thread return");
 
 	if(td.curRun >= td.roomForRuns) {
 		td.roomForRuns <<= 1;

--- a/dmg/partition.c
+++ b/dmg/partition.c
@@ -514,7 +514,7 @@ int writeDriverDescriptorMap(int pNum, AbstractFile* file, DriverDescriptorRecor
   bufferFile = createAbstractFileFromMemory((void**)&buffer, DDM_SIZE * BlockSize);
   
   blkx = insertBLKX(file, bufferFile, DDM_OFFSET, DDM_SIZE, DDM_DESCRIPTOR, CHECKSUM_UDIF_CRC32, &CRCProxy, &uncompressedToken,
-            dataForkChecksum, dataForkToken, NULL, 0, NULL);
+            dataForkChecksum, dataForkToken, NULL, NULL);
               
   blkx->checksum.data[0] = uncompressedToken.crc;
   
@@ -552,7 +552,7 @@ int writeApplePartitionMap(int pNum, AbstractFile* file, Partition* partitions, 
   bufferFile = createAbstractFileFromMemory((void**)&buffer, realPartitionSize);
    
   blkx = insertBLKX(file, bufferFile, PARTITION_OFFSET * BlockSize / SECTOR_SIZE, realPartitionSize / SECTOR_SIZE, pNum, CHECKSUM_UDIF_CRC32,
-              &BlockCRC, &uncompressedToken, dataForkChecksum, dataForkToken, NULL, 0, NULL);
+              &BlockCRC, &uncompressedToken, dataForkChecksum, dataForkToken, NULL, NULL);
   
   bufferFile->close(bufferFile);
 
@@ -606,12 +606,12 @@ int writeATAPI(int pNum, AbstractFile* file, unsigned int BlockSize, ChecksumFun
   if(BlockSize != SECTOR_SIZE)
   {
     blkx = insertBLKX(file, bufferFile, ATAPI_OFFSET, BlockSize / SECTOR_SIZE, pNum, CHECKSUM_UDIF_CRC32,
-                &BlockCRC, &uncompressedToken, dataForkChecksum, dataForkToken, NULL, 0, NULL);
+                &BlockCRC, &uncompressedToken, dataForkChecksum, dataForkToken, NULL, NULL);
   }
   else
   {
     blkx = insertBLKX(file, bufferFile, ATAPI_OFFSET, ATAPI_SIZE, pNum, CHECKSUM_UDIF_CRC32,
-                &BlockCRC, &uncompressedToken, dataForkChecksum, dataForkToken, NULL, 0, NULL);
+                &BlockCRC, &uncompressedToken, dataForkChecksum, dataForkToken, NULL, NULL);
   }
 
   bufferFile->close(bufferFile);

--- a/includes/dmg/dmg.h
+++ b/includes/dmg/dmg.h
@@ -277,13 +277,11 @@ extern "C" {
 	uint32_t checksumBitness(uint32_t type);
 
 	uint32_t CRC32Checksum(uint32_t* crc, const unsigned char *buf, size_t len);
-	uint32_t CRC32ZeroesChecksum(uint32_t* crc, size_t len);    
 	uint32_t MKBlockChecksum(uint32_t* ckSum, const unsigned char* data, size_t len);
 
 	void BlockSHA1CRC(void* token, const unsigned char* data, size_t len);
 	void BlockCRC(void* token, const unsigned char* data, size_t len);
 	void CRCProxy(void* token, const unsigned char* data, size_t len);
-	void CRCZeroesProxy(void* token, size_t len);
 
 	void SHA1Init(SHA1_CTX* context);
 	void SHA1Update(SHA1_CTX* context, const uint8_t* data, const size_t len);

--- a/includes/dmg/dmg.h
+++ b/includes/dmg/dmg.h
@@ -330,7 +330,7 @@ extern "C" {
 	void extractBLKX(AbstractFile* in, AbstractFile* out, BLKXTable* blkx);
 	BLKXTable* insertBLKX(AbstractFile* out, AbstractFile* in, uint32_t firstSectorNumber, uint32_t numSectors, uint32_t blocksDescriptor,
 	            uint32_t checksumType, ChecksumFunc uncompressedChk, void* uncompressedChkToken, ChecksumFunc compressedChk,
-				void* compressedChkToken, Volume* volume, int addComment, AbstractAttribution* attribution);
+				void* compressedChkToken, Volume* volume, AbstractAttribution* attribution);
 
 
 	int extractDmg(AbstractFile* abstractIn, AbstractFile* abstractOut, int partNum);


### PR DESCRIPTION
Uses parallelism when building a dmg, as [proposed in bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1916320). On my 12-core system, it goes from 30s to 5s.

Tested on Ubuntu 22.04 with:
```
$ curl -Lo orig.dmg 'https://download-installer.cdn.mozilla.net/pub/firefox/releases/130.0/mac/en-CA/Firefox%20130.0.dmg'
$ md5sum orig.dmg
6bcf91f8632dc7751a6736354155750c
$ git checkout mozilla
$ cmake -DCMAKE_BUILD_TYPE=Release
$ make -j12
$ dmg/dmg extract orig.dmg orig.hfs >/dev/null
$ md5sum orig.hfs
e68bcc9b1de3ccf899aa46151df77b52
$ time dmg/dmg build orig.hfs base.dmg __MOZCUSTOM__ > /dev/null
30.25s user 0.22s system 99% cpu 30.481 total
$ git checkout mozilla-parallel
$ make -j12
$ time dmg/dmg build orig.hfs parallel.dmg __MOZCUSTOM__ > /dev/null
47.04s user 1.98s system 867% cpu 5.654 total
$ md5sum base.dmg parallel.dmg
0d2c2af7c3b0dfe2950d5974536bfd33  base.dmg
0d2c2af7c3b0dfe2950d5974536bfd33  parallel.dmg
```

Overall it looks like a big change, but each of the commits is independent, small and relatively self-explanatory (I hope). Some design notes that may be helpful:

* We use N identical threads, which can compress in parallel, but only one thread can be reading or writing at a time. This allows serial tasks such as checksums to remain serialized, as long as they happen at read-time or write-time.
* When we finish compressing a block, we can't write it until any previous blocks are ready, so we keep a linked-list queue of pending blocks.
* I've made a couple of small changes or simplifications as I went:
   * All the `addComment`-related code was completely unused, so I removed it.
   * I've removed the unused CRCZeroes stuff, and replaced CRC32 with a call to zlib. It's faster!
   * I commented out many print statements, `dmg` was getting far too verbose to be useful
   * Instead of referring to `blkx->runs[curRun]` over and over again, I use a local BLKXRun variable 
   * We no longer seek back-and-forth in the input file. If we already read the "next block", we just reuse it as our next "current block"
   * I've disentangled the "should this block be raw?" decision from the writing code. This means one fewer callsite of `out->write()` and `compressedChk()`, which I think is simpler.

cc @bhearsum 