### PR TITLE
Run Linux tests in Docker

### DIFF
--- a/.github/workflows/cram-tests.yml
+++ b/.github/workflows/cram-tests.yml
@@ -7,24 +7,8 @@ on:
     branches: ["mozilla"]
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-22.04, macos-14]
-        pattern: ["test/*.t", "test/reference/*.t"]
-        include:
-          - os: ubuntu-22.04
-            pattern: "test/*.t"
-          - os: macos-14
-            pattern: "test/reference/*.t"
-        exclude:
-          - os: ubuntu-22.04
-            pattern: "test/reference/*.t"
-          - os: macos-14
-            pattern: "test/*.t"
-
+  mac:
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - name: configure
@@ -34,4 +18,17 @@ jobs:
     - name: test
       run: |
         pip install cram
-        cram ${{ matrix.pattern }}
+        cram test/reference/*.t
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: docker/setup-buildx-action@v3
+    - name: docker build
+      uses: docker/build-push-action@v6
+      with:
+        load: true
+        tags: libdmg-hfsplus:test
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+    - name: test
+      run: docker run --rm libdmg-hfsplus:test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM ubuntu:noble AS apt
-RUN apt-get update
+FROM ubuntu:noble AS base
 
-FROM apt AS build
-RUN apt-get install -y g++ cmake make libbz2-dev libz-dev
+FROM base AS build
+RUN apt-get update && apt-get install -y g++ cmake make libbz2-dev libz-dev
 RUN mkdir -p /source
 COPY CMakeLists.txt /source
 COPY common /source/common
@@ -13,8 +12,8 @@ COPY hfs /source/hfs
 RUN cmake -B /build /source
 RUN make -C /build -j$(nproc)
 
-FROM apt AS test
-RUN apt-get install -y pipx perl xxd
+FROM base AS test
+RUN apt-get update && apt-get install -y pipx perl xxd
 # We never want to actually make anything
 RUN ln -s /bin/true /bin/make
 RUN pipx install cram

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:noble AS apt
+RUN apt-get update
+
+FROM apt AS build
+RUN apt-get install -y g++ cmake make libbz2-dev libz-dev
+RUN mkdir -p /source
+COPY CMakeLists.txt /source
+COPY common /source/common
+COPY includes /source/includes
+COPY hdutil /source/hdutil
+COPY dmg /source/dmg
+COPY hfs /source/hfs
+RUN cmake -B /build /source
+RUN make -C /build -j$(nproc)
+
+FROM apt AS test
+RUN apt-get install -y pipx perl xxd
+# We never want to actually make anything
+RUN ln -s /bin/true /bin/make
+RUN pipx install cram
+ENV PATH="/usr/bin:/root/.local/bin"
+RUN mkdir -p /test/build/dmg /test/build/hfs
+COPY --from=build /build/dmg/dmg /test/build/dmg/dmg
+COPY --from=build /build/hfs/hfsplus /test/build/hfs/hfsplus
+COPY test /test/test
+WORKDIR /test
+CMD ["/bin/sh", "-c", "cram test/*.t"]

--- a/README.markdown
+++ b/README.markdown
@@ -77,6 +77,9 @@ The makefile in the root folder will make all utilities.
 TESTING
 -------
 
+To run tests automatically, ensure you have Docker and docker-buildx installed. Then run `./test/run_tests.sh`.
+
+Or to run tests manually:
 * Configure in 'build': `cmake -B build`
 * Install cram: `pipx install cram`
 * Run tests: `cram test/*.t`

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -ex
+docker buildx build --progress=plain --tag libdmg-hfsplus "$(dirname "$0")/.."
+docker run libdmg-hfsplus


### PR DESCRIPTION
Tests can be run in docker with `./test/run_tests.sh`. And these are run in CI!

Allows users/devs to run tests in a fully reproducible environment. This means we shouldn't be affected by things like changes in libc's `rand()`, any changes Github makes to their Actions runners, etc. Can even run Linux tests accurately in macOS.