### PR TITLE
Error on unknown compression method

### DIFF
--- a/dmg/io.c
+++ b/dmg/io.c
@@ -449,7 +449,8 @@ void extractBLKX(AbstractFile* in, AbstractFile* out, BLKXTable* blkx) {
 			case BLOCK_TERMINATOR:
 				break;
 			default:
-				break;
+				fprintf(stderr, "Unknown block type: %#08x\n", blkx->runs[i].type);
+				exit(1);
 		}
 	}
 


### PR DESCRIPTION
Previously, when we encountered a block with unknown type, we yield success wth corrupt output. Seems bad!

To test, run with the file inside the attached zip: `./build/dmg/dmg extract ulmo.dmg out.hfs`. Now we yield exit status 1.

Not sure this is worth writing a test for, but up to you.

[ulmo.zip](https://github.com/user-attachments/files/17638570/ulmo.zip)

r? @bhearsum 