### PR TITLE
Handle potentially-undefined liblzma constant

### DIFF
--- a/dmg/compress.c
+++ b/dmg/compress.c
@@ -8,6 +8,14 @@
 #ifdef HAVE_LIBLZMA
   #include <lzma.h>
 
+  // LZMA_FAIL_FAST was introduced in 5.3.3, attempting to use it in earlier versions
+  // yields an error.
+  #ifdef LZMA_FAIL_FAST
+    #define LZMA_DECODE_OPTS LZMA_FAIL_FAST
+  #else
+    #define LZMA_DECODE_OPTS 0
+  #endif
+
   static int lzmaDecompress(unsigned char* inBuffer, size_t inSize, unsigned char* outBuffer, size_t outBufSize, size_t *decompSize)
   {
     lzma_ret lret;
@@ -16,7 +24,7 @@
     size_t inPos = 0;
     *decompSize = 0;
 
-    lret = lzma_stream_buffer_decode(&error_if_memory_usage_exceeds, LZMA_FAIL_FAST, NULL,
+    lret = lzma_stream_buffer_decode(&error_if_memory_usage_exceeds, LZMA_DECODE_OPTS, NULL,
       inBuffer, &inPos, inSize, outBuffer, decompSize, outBufSize);
     return lret != LZMA_OK;
   }


### PR DESCRIPTION
Older versions of liblza, such as the one in Debian jessie, don't have LZMA_FAIL_FAST.

Treeherder build demonstrating the problem: https://treeherder.mozilla.org/jobs?repo=try&revision=cf21f080bed315d1ce5693ca0f05f49f22c8f857

With this fix: https://treeherder.mozilla.org/jobs?repo=try&revision=ee55201a8746212023e420053d5baee6f7ab229c&selectedTaskRun=XV8l0rzySrSqIxNpsnYgag.0

cc @bhearsum 