### PR TITLE
Ignore local VSCode and Mac dot files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 /venv/
 /test/*.t.err
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 /venv/
 /test/*.t.err
 .DS_Store
+.vscode/settings.json


### PR DESCRIPTION
I'm developing from a Mac, which loves to dump little .DS_Store files all over. Those should not be checked in. I'm also developing from VSCode, with my own idiosyncratic local workspace config, which also should not be checked in.

I propose updating .gitignore to exclude this debris. (If you'd rather not, I'll use `.git/info/exclude` instead, but I'm used to seeing this kind of very common "debris file" listed in project `.gitignore`s.)