### PR TITLE
Disable optimizations around the strict aliasing rule.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 /venv/
 /test/*.t.err
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 /venv/
 /test/*.t.err
 .DS_Store
+.vscode/settings.json

--- a/dmg/CMakeLists.txt
+++ b/dmg/CMakeLists.txt
@@ -29,6 +29,7 @@ link_directories(${BZIP2_LIBRARIES})
 link_directories(${PROJECT_BINARY_DIR}/common ${PROJECT_BINARY_DIR}/hfs)
 
 add_library(dmg adc.c attribution.c checksum.c compress.c dmgfile.c dmglib.c filevault.c io.c partition.c resources.c udif.c ../includes/dmg/adc.h ../includes/dmg/attribution.h ../includes/dmg/dmg.h ../includes/dmg/dmgfile.h ../includes/dmg/dmglib.h ../includes/dmg/filevault.h)
+target_compile_options(dmg PUBLIC -fno-strict-aliasing)
 
 IF(OPENSSL_FOUND)
 	add_definitions(-DHAVE_CRYPT)

--- a/hfs/CMakeLists.txt
+++ b/hfs/CMakeLists.txt
@@ -9,6 +9,7 @@ link_directories(${ZLIB_LIBRARIES})
 
 link_directories (${PROJECT_BINARY_DIR}/common)
 add_library(hfs btree.c catalog.c extents.c xattr.c fastunicodecompare.c flatfile.c hfslib.c rawfile.c utility.c volume.c hfscompress.c ../includes/hfs/hfslib.h ../includes/hfs/hfsplus.h ../includes/hfs/hfscompress.h)
+target_compile_options(hfs PUBLIC -fno-strict-aliasing)
 target_link_libraries(hfs common z)
 
 add_executable(hfsplus hfs.c)


### PR DESCRIPTION
One of C's many pitfalls is the Strict Aliasing Rule: C (and especially C++) has narrow rules about the type of variable, reference, or pointer a field may be accessed through. The optimizer is permitted to assume that fields, aliases, and references to incompatible types (using a highly specific definition of "incompatible") do not refer to the same object, resulting in chaos and misery when they do, in fact, refer to the same object. See https://www.gnu.org/software/c-intro-and-ref/manual/html_node/Aliasing-Type-Rules.html for more.

As is common with C codebases doing low-level serialization, `libdmg-hfsplus` violates the strict aliasing rule. Target `hfs` casts pointers to `HFSPlusCatalogRecord` to and from `HFSPlusCatalogFolder`, `HFSPlusCatalogFile`, and `HFSPlusCatalogThread`.  Target `dmg` appears to generally be more rigorous, going through `unsigned char*` backing fields (which _are_ allowed to be reinterpreted by "struct stencils" and other type puns), but there are spots where it goes through `uint8_t*` and that is _technically_ not necessarily a character type. I thought I noticed a more substantial issue when I wrote this patch but I can't find it now that I'm trying to write this message.

Anyway, GCC (and clang) offers C compilation flag `-fno-strict-aliasing`, which tells it not to apply any optimizations based solely on assuming that the strict aliasing rule is followed. Since these optimizations would be unsafe in `hfs` and _probably_ unsafe in `dmg`, anything compiled against them needs to be compiled without them. This pull request configures the build accordingly.

This may make the binary slightly less efficient in various dimensions in an optimized build if this shuts off optimizations that were doing something useful. However, squeezing all aliasing violations out of a C codebase using "struct punning" is very difficult, so confessing our sins to the optimizer so it will make an effort to tolerate this undefined behavior seems more practical to me.

This pull request is intended to be applied on top of https://github.com/mozilla/libdmg-hfsplus/pull/17. I'll rebase and edit this as needed to pick up changes on (or an outright rejection of) that branch.